### PR TITLE
Fix wording in the /rollcall command

### DIFF
--- a/commands/rollcall.js
+++ b/commands/rollcall.js
@@ -13,7 +13,7 @@ module.exports = {
 		const embed = getRollcallEmbed();
 		await interaction.reply({ content: 'Rollcall initiated', ephemeral: true });
 		await attendanceChannel.send({ content: `----------------**ATTENDANCE**----------------\nBelow are attendance records for the match against **${team}** on **${date}**\n -----------------------------------------------` });
-		await annoucementsChannel.send({ content: `@everyone It is that time again! Please use the buttons below to let us know your availability for Week ${week} as soon as you can... \n\n**_Please_ only select 1 option**\n\n`, embeds: [embed], components: [replyButtons] });
+		await annoucementsChannel.send({ content: `@everyone It is that time again! Please use the buttons below to let us know your availability for Week ${week} as soon as you can... \n\n`, embeds: [embed], components: [replyButtons] });
 	},
 };
 


### PR DESCRIPTION
### Description

> Now that rollcall supports multiple commands, there is no need to include a line about only selecting a single option. The bot should now properly handle and respond if choose to switch your response, or if you select the status that you already have. If this is not handled properly, we should file a bug in a separate PR

### Commits:
- B** Remove wording about only one response